### PR TITLE
better cmake for debug

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,14 +1,21 @@
 cmake_minimum_required (VERSION 2.8)
 project (pyscf)
+enable_language(Fortran)
 
-include(arch.inc OPTIONAL)
+#include(arch.inc OPTIONAL)
 
-set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
-#set(CMAKE_BUILD_TYPE DEBUG)
-set(CMAKE_VERBOSE_MAKEFILE OFF)
+#set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
+IF( NOT CMAKE_BUILD_TYPE )
+  SET( CMAKE_BUILD_TYPE Release ... FORCE )
+ENDIF()
 
 if (CMAKE_COMPILER_IS_GNUCC) # Does it skip the link flag on old OsX?
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffast-math")
+  set(CMAKE_C_FLAGS_DEBUG "-Wall -pg -O0")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ")
+  set(CMAKE_C_FLAGS_RELEASE "-Wall -O2 -ffast-math")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-pedantic -pg -DDEBUG -O0 -fbounds-check -fbacktrace -Wall -ffree-line-length-0")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-pedantic -O2 -Wall -ffree-line-length-0")
   if(UNIX AND NOT APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
   endif()
@@ -16,6 +23,7 @@ endif()
 
 set(CMAKE_MACOSX_RPATH OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 
 if (DEFINED BLAS_LIBRARIES)
   message("BLAS libraries are defined (in arch.inc):")
@@ -48,7 +56,6 @@ message("BLAS libraries: ${BLAS_LIBRARIES}")
 
 # set(BLAS_LIBRARIES "-Wl,-rpath=${MKLROOT}/lib/intel64/ ${BLAS_LIBRARIES}")
 
-enable_language(Fortran)
 include(FortranCInterface)
 FortranCInterface_HEADER(FC.h MACRO_NAMESPACE “FC_”)
 #This creates a “FC.h” header that defines mangling macros

--- a/lib/nao/CMakeLists.txt
+++ b/lib/nao/CMakeLists.txt
@@ -10,7 +10,7 @@ set_target_properties(nao PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_D
   )
 
 #target_compile_options(nao PRIVATE -pedantic -g -DDEBUG -O0 -fbounds-check -fbacktrace -Wall -ffree-line-length-0)
-target_compile_options(nao PRIVATE -pedantic -g -DDEBUG -O2 -Wall -ffree-line-length-0)
+#target_compile_options(nao PRIVATE -pedantic -g -DDEBUG -O2 -Wall -ffree-line-length-0)
 
 # - Find FFTW
 # Find the native FFTW includes and library

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,25 @@ from distutils.core import setup
 import subprocess
 import os
 
-def compile_C_code(verbose=0):
+def compile_C_code(verbose=0, build_type="Release"):
     """
     Compile automaticaly the C and Fortran code
     when installing the program with python setup.py
     """
+
+    if build_type not in ["Release", "Debug", "None"]:
+        raise ValueError("build type must be Release, Debug or None")
     ret = subprocess.call("rm -rf lib/build", shell = True)
 
     os.mkdir("lib/build")
     os.chdir("lib/build")
 
-    ret = subprocess.call("cmake ..", shell = True)
-    comp = "make VERBOSE={0}".format(verbose)
+    cmd = "cmake -DCMAKE_BUILD_TYPE=" + build_type + " .."
+    ret = subprocess.call(cmd, shell = True)
     if ret != 0:
         raise ValueError("cmake returned error {0}".format(ret))
-    ret = subprocess.call(comp, shell = True)
+    cmd = "make VERBOSE={0}".format(verbose)
+    ret = subprocess.call(cmd, shell = True)
     if ret != 0:
         raise ValueError("make returned error {0}".format(ret))
 
@@ -62,7 +66,7 @@ VERSION          = '1.3.0'
 
 compilation = True
 if compilation:
-    compile_C_code()
+    compile_C_code(build_type="Debug")
 
 setup(
     name=NAME,


### PR DESCRIPTION
Hello Peter,

I corrected the CMake files in order that it uses correctly debug flags or not.
If you want to compile with debug flags, you should specifie in the setup.py file build_type="Debug".

Otherwise, for using the optimal flag you should use build_type="Release"