### PR TITLE
improving compilation and installation process

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,0 +1,52 @@
+from __future__ import division
+import numpy as np
+import argparse
+import os
+import subprocess
+
+
+def compile_C_code(verbose=0, build_type="Release"):
+    """
+        Compile automaticaly the C and Fortran code
+        when installing the program with python setup.py
+    """
+
+    if build_type not in ["Release", "Debug", "None"]:
+        raise ValueError("build type must be Release, Debug or None")
+
+    ret = subprocess.call("rm -rf lib/build", shell = True)
+    os.mkdir("lib/build")
+    os.chdir("lib/build")
+
+    cmd = "cmake -DCMAKE_BUILD_TYPE=" + build_type + " .."
+    ret = subprocess.call(cmd, shell = True)
+    if ret != 0:
+        raise ValueError("cmake returned error {0}".format(ret))
+
+    cmd = "make VERBOSE={0}".format(verbose)
+    ret = subprocess.call(cmd, shell = True)
+    if ret != 0:
+        raise ValueError("make returned error {0}".format(ret))
+    os.chdir("../..")
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--command', type=str, default = "install", help="run: python setup.py <command>")
+parser.add_argument('--compile', type=int, default = 1, help="compile C and Fortran code")
+parser.add_argument('--build_type', type=str, default = "Release", help="compile code in Release or Debug mode")
+parser.add_argument('--verbose', type=int, default = 0, help="verbosity for compilation")
+
+args = parser.parse_args()
+
+if args.compile==1:
+    compile_C_code(verbose=args.verbose, build_type=args.build_type)
+
+if args.command not in ["install", "build", "None"]:
+    raise ValueError("command must be build or install")
+
+if args.command != "None":
+    cmd = "python setup.py " + args.command
+    ret = subprocess.call(cmd, shell = True)
+    if ret != 0:
+        raise ValueError(cmd + " returned error {0}".format(ret))

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,7 @@
 import sys
 import subprocess
 from distutils.core import setup
-import subprocess
 import os
-
-def compile_C_code(verbose=0, build_type="Release"):
-    """
-    Compile automaticaly the C and Fortran code
-    when installing the program with python setup.py
-    """
-
-    if build_type not in ["Release", "Debug", "None"]:
-        raise ValueError("build type must be Release, Debug or None")
-    ret = subprocess.call("rm -rf lib/build", shell = True)
-
-    os.mkdir("lib/build")
-    os.chdir("lib/build")
-
-    cmd = "cmake -DCMAKE_BUILD_TYPE=" + build_type + " .."
-    ret = subprocess.call(cmd, shell = True)
-    if ret != 0:
-        raise ValueError("cmake returned error {0}".format(ret))
-    cmd = "make VERBOSE={0}".format(verbose)
-    ret = subprocess.call(cmd, shell = True)
-    if ret != 0:
-        raise ValueError("make returned error {0}".format(ret))
-
-    os.chdir("../..")
-
 
 if sys.version_info[0] >= 3: # from Cython 0.14
     from distutils.command.build_py import build_py_2to3 as build_py
@@ -62,11 +36,6 @@ AUTHOR           = 'Qiming Sun'
 AUTHOR_EMAIL     = 'osirpt.sun@gmail.com'
 PLATFORMS        = ['Linux', 'Mac OS-X', 'Unix']
 VERSION          = '1.3.0'
-
-
-compilation = True
-if compilation:
-    compile_C_code(build_type="Debug")
 
 setup(
     name=NAME,


### PR DESCRIPTION
Hello Peter,

Taking into account your last comments I tried to improve the installation and compilation pocess of pyscf.

Now you just need to run the command,
python install.py

This will compile and install the code in your python path.

if you want to compile with Debug flags you can use
python install.py --build_type Debug

if you don't want to compile at all
python install.py --compile 0

and if you just want to build the program and not install it in your python path,
python install.py --command build

Obviously you can mix the different options. With this new method no need to modify files.

marc